### PR TITLE
relatorios p/ professores cujos alunos são orientados pela tabela cursos

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,7 @@ def cadastro():
                 'local_nasc': request.form.get('local_nasc'),
                 'nacionalidade': request.form.get('nacionalidade'),
                 'lattes': request.form.get('lattes'),
+                'orientador': request.form.get('orientador')
             })
         elif tipo == 'professor':
             dados['nusp'] = request.form.get('nusp')

--- a/conn_bd.py
+++ b/conn_bd.py
@@ -153,8 +153,8 @@ def busca_orientador(nusp_aluno=None):
     
     query = """
         SELECT orientador
-        FROM cursos c
-        WHERE c.aluno = %s AND c.ativo = TRUE
+        FROM alunos a
+        WHERE a.nusp = %s
     """
     
     conn = get_db_conn()
@@ -459,10 +459,10 @@ def cadastrar_usuario(tipo, dados):
                 return False
 
             cur.execute(""" 
-                INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes) 
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, orientador) 
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """, (dados['nusp'], dados['nome'], dados['email'], dados['senha'],
-                  dados['data_nasc'], dados['rg'], dados['local_nasc'], dados['nacionalidade'], dados['lattes']))
+                  dados['data_nasc'], dados['rg'], dados['local_nasc'], dados['nacionalidade'], dados['lattes'], dados['orientador']))
 
         elif tipo == 'professor':
             cur.execute("SELECT * FROM professores WHERE nusp = %s", (dados['nusp'],))

--- a/static/bd/bd.sql
+++ b/static/bd/bd.sql
@@ -24,7 +24,12 @@ CREATE TABLE alunos (
   local_nasc VARCHAR(20) NOT NULL,
   nacionalidade VARCHAR(20) NOT NULL,
   lattes VARCHAR(50) NOT NULL,
-  status_aluno status_aluno
+  orientador INT NOT NULL,
+  status_aluno status_aluno,
+
+  CONSTRAINT fk_orientador
+    FOREIGN KEY (orientador) 
+    REFERENCES professores(nusp)
 );
 
 CREATE TABLE cursos (

--- a/static/bd/bd.sql
+++ b/static/bd/bd.sql
@@ -36,6 +36,7 @@ CREATE TABLE cursos (
   data_aprov_exam_qual DATE NOT NULL,
   data_aprov_exam_prof DATE NOT NULL,
   data_limite DATE NOT NULL,
+  ativo BOOLEAN NOT NULL,
   
   FOREIGN KEY (aluno)REFERENCES alunos(nusp),
   FOREIGN KEY (orientador) REFERENCES professores(nusp)

--- a/static/bd/inserts.sql
+++ b/static/bd/inserts.sql
@@ -1,16 +1,16 @@
 INSERT INTO professores (nusp, nome, senha) VALUES (1, 'Dr. Silva', 'senha123');
 INSERT INTO professores (nusp, nome, senha) VALUES (2, 'Dr. Souza', 'senha123');
 
-INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, status_aluno) 
-VALUES (123456, 'Carlos', 'carlos@dominio.com', 'senha123', '1995-06-12', '123456789', 'São Paulo', 'Brasileiro', 'http://lattes.carlos.com', 'Ativo');
-INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, status_aluno) 
-VALUES (789101, 'Ana', 'ana@dominio.com', 'senha123', '1996-07-23', '987654321', 'Rio de Janeiro', 'Brasileira', 'http://lattes.ana.com', 'Ativo');
-INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, status_aluno) 
-VALUES (654321, 'João', 'joao@dominio.com', 'senha123', '1994-04-10', '123789456', 'Belo Horizonte', 'Brasileiro', 'http://lattes.joao.com', 'Ativo');
-INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, status_aluno) 
-VALUES (112233, 'Maria', 'maria@dominio.com', 'senha123', '1997-08-19', '456123789', 'Curitiba', 'Brasileira', 'http://lattes.maria.com', 'Inativo');
-INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, status_aluno) 
-VALUES (445566, 'Pedro', 'pedro@dominio.com', 'senha123', '1995-12-25', '321654987', 'São Paulo', 'Brasileiro', 'http://lattes.pedro.com', 'Inativo');
+INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, orientador, status_aluno) 
+VALUES (123456, 'Carlos', 'carlos@dominio.com', 'senha123', '1995-06-12', '123456789', 'São Paulo', 'Brasileiro', 'http://lattes.carlos.com', 1, 'Ativo');
+INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, orientador, status_aluno) 
+VALUES (789101, 'Ana', 'ana@dominio.com', 'senha123', '1996-07-23', '987654321', 'Rio de Janeiro', 'Brasileira', 'http://lattes.ana.com', 2,'Ativo');
+INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, orientador, status_aluno) 
+VALUES (654321, 'João', 'joao@dominio.com', 'senha123', '1994-04-10', '123789456', 'Belo Horizonte', 'Brasileiro', 'http://lattes.joao.com', 2, 'Ativo');
+INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, orientador, status_aluno) 
+VALUES (112233, 'Maria', 'maria@dominio.com', 'senha123', '1997-08-19', '456123789', 'Curitiba', 'Brasileira', 'http://lattes.maria.com', 1,'Inativo');
+INSERT INTO alunos (nusp, nome, email, senha, data_nasc, rg, local_nasc, nacionalidade, lattes, orientador, status_aluno) 
+VALUES (445566, 'Pedro', 'pedro@dominio.com', 'senha123', '1995-12-25', '321654987', 'São Paulo', 'Brasileiro', 'http://lattes.pedro.com', 2,'Inativo');
 
 INSERT INTO relatorios (titulo, atividades_resp, pesquisas_resp, observacoes_resp, dificuldade, data_envio, nota_professor, nota_ccp, parecer_professor, parecer_ccp, aluno, orientador, escrita, aval, publicados) 
 VALUES ('Relatório teste 1', 'Texto para o primeiro relatório de teste.', 'Pesquisas realizadas pelo aluno.', 'Observações do relatório.', 'Sim', '2022-10-10 11:30:30', 'Aguardando', 'Aguardando', 'Parecer ainda não enviado.', 'Parecer ainda não enviado.', 123456, 1, 'S', 'S', 'S');
@@ -35,10 +35,3 @@ VALUES ('Relatório teste 9', 'Texto para o nono relatório de teste.', 'Pesquis
 
 INSERT INTO data_entrega_relatorio (data_entrega_relatorio)
 VALUES ('1995-06-12');
-
-INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Mestrado', 1, 445566, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
-INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Mestrado', 2, 112233, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
-INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Doutorado', 3, 654321, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
-INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Mestrado', 4, 789101, 2, '2021-06-12', '2021-01-12', '2021-01-01', '2023-12-01', false);
-INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Doutorado', 5, 789101, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
-INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Doutorado', 6, 123456, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);

--- a/static/bd/inserts.sql
+++ b/static/bd/inserts.sql
@@ -35,3 +35,10 @@ VALUES ('Relatório teste 9', 'Texto para o nono relatório de teste.', 'Pesquis
 
 INSERT INTO data_entrega_relatorio (data_entrega_relatorio)
 VALUES ('1995-06-12');
+
+INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Mestrado', 1, 445566, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
+INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Mestrado', 2, 112233, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
+INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Doutorado', 3, 654321, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
+INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Mestrado', 4, 789101, 2, '2021-06-12', '2021-01-12', '2021-01-01', '2023-12-01', false);
+INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Doutorado', 5, 789101, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);
+INSERT INTO cursos (nome, id, aluno, orientador, data_matricula, data_aprov_exam_qual, data_aprov_exam_prof, data_limite, ativo) VALUES ('Doutorado', 6, 123456, 2, '2024-06-12', '2024-01-12', '2024-01-01', '2025-06-12', true);

--- a/templates/cadastro.html
+++ b/templates/cadastro.html
@@ -55,6 +55,7 @@
                     <label for="local_nasc">Local de Nascimento:</label><input type="text" name="local_nasc" required><br>
                     <label for="nacionalidade">Nacionalidade:</label><input type="text" name="nacionalidade" required><br>
                     <label for="lattes">Lattes:</label><input type="text" name="lattes" required><br>
+                    <label for="orientador">Orientador (Número USP):</label><input type="text" name="orientador" required><br>
                 `;
             } 
         });


### PR DESCRIPTION
Agora os relatorios enviados pelos alunos vão para os professores orientadores dos alunos por meio da tabela cursos (antes todos estavam indo para o professor de id = 1).

Mudança no BD:
- campo 'orientador' (nusp do orientador) na tabela de alunos;

Mudança no cadastro:
- campo para o aluno preencher o nusp do orientador
